### PR TITLE
Updating Makefile, sample Docker Compose, documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,13 @@ release: ## tag a release from master and push to origin
 	git push --tags
 
 build: ## build the Docker image for this app
-	docker build --network=host --tag $(REPO) --rm=false .
+	docker build --network=host --tag $(REPO):$(VERSION) --rm=false .
 
 login: ## Login to docker hub
 	docker login -u $(ORG)
 
 push: ## push the latest Docker image to DockerHub
-	docker push $(REPO)
+	docker push $(REPO):$(VERSION)
 
 shell: ## run an interactive bash session in the container
 	docker run -it $(REPO) /bin/bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - /home/lab/src/comicrack-docker/roaming:/wine32/drive_c/users/abc/AppData/Roaming/cYo/ComicRack
       - /mnt/ds1618/comics:/config/comics
     ports:
-      - 9001:3001
+      - 3001:3001
     networks:
       - comicrack
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     image: lscr.io/linuxserver/mariadb:10.5.17
     container_name: mariadb
     environment:
-      - PUID=1024
-      - PGID=1000
+      - PUID=1024   # Change this to your user ID to preserve file permissions
+      - PGID=1000   # Change this to your group ID to preserve file permissions
       - TZ=Etc/UTC
     volumes:
       - /home/lab/src/comicrack-docker/mariadb:/config
@@ -20,15 +20,16 @@ services:
     depends_on:
       - mariadb
     environment:
-      - PUID=1024
-      - PGID=1000
+      - PUID=1024   # Change this to your user ID to preserve file permissions
+      - PGID=1000   # Change this to your group ID to preserve file permissions
       - TZ=Etc/UTC
     volumes:
       - /home/lab/src/comicrack-docker/local:/wine32/drive_c/users/abc/AppData/Local/cYo/ComicRack
       - /home/lab/src/comicrack-docker/roaming:/wine32/drive_c/users/abc/AppData/Roaming/cYo/ComicRack
       - /mnt/ds1618/comics:/config/comics
     ports:
-      - 3001:3001
+      - 3001:3001  # Default port mapping - in the case of port collision, change this to something else
+    restart: unless-stopped
     networks:
       - comicrack
 networks:

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,17 +5,9 @@ lowest.
 
 - [ ] Adding Comic Vine scraping support
 - [ ] General Scripts/Plugins support and documentation
-- [ ] Moving the wine32 prefix to something outside of `/config` to help standardize on the LinuxServer container model
+- [x] Moving the wine32 prefix to something outside of `/config` to help standardize on the LinuxServer container model
 - [ ] Adding community fixes (rar5, etc)
 - [ ] Documentation on backing up the ComicVine Database, and restoring it.
 - [ ] Documentation/testing on importing an existing ComicVine database (not from this project)
 - [ ] Better tagging for dockerhub container
-- [ ] Other misc export/import for things like `ComicRack.xml`
-
-## Notes
-
-Currently, the wine prefix is in `/config/.wine32` - and this directory is blown away with the standard LinuxServer
-`/path/to/config:/config` volume mount. When we move the installation, it will require a fresh Docker image build, and
-possibly some additional scripts in `/root/etc/cont-init.d` to allow for a
-  singular volume mount `/path/to/comicrack/config:/config` while still allowing for the `roaming`, `local`, and any
-  other critical wine directories to be mounted.
+- [ ] Other misc export/import for things like `ComicDB.xml`, `ComicRack.ini`, etc


### PR DESCRIPTION
- Fixes some bugs with the Makefile (allowing for version pushing)
- Updates the sample `docker-compose.yml` file to restart unless stopped, changes the exposed port to be identical to the internal port, adding comments to explain/call out PUID/PGID
- Updating the todo.md documentation